### PR TITLE
Economy: Offline Fallback (Fixes #13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.8.0] - 2026-03-22 [Author: Filip Houdek]
+### Fixed
+- Economy offline fallback: cache save data to localStorage on every state change and after successful cloud saves, ensuring a recent local backup is always available (Fixes #13).
+
 ## [0.7.5] - 2026-03-22 [Author: Tobias Mrazek]
 ### Fixed
 - Improve mobile experience.

--- a/frontend/context/EconomyContext.tsx
+++ b/frontend/context/EconomyContext.tsx
@@ -286,6 +286,12 @@ export function EconomyProvider({ children }: { children: React.ReactNode }) {
             const data = await response.json();
             applySaveData(data.saveData);
             setCloudStatus("synced");
+            try {
+                const key = `industrialist_save_${credentialsRef.current.username || "guest"}`;
+                if (typeof window !== "undefined" && window.localStorage) {
+                    window.localStorage.setItem(key, JSON.stringify(payload));
+                }
+            } catch { void 0; }
             return true;
         } catch {
             try {
@@ -454,6 +460,19 @@ export function EconomyProvider({ children }: { children: React.ReactNode }) {
         }, 5000);
         return () => clearInterval(interval);
     }, [isAuthenticated, processProductionTick]);
+
+    useEffect(() => {
+        if (!isAuthenticated) return;
+        try {
+            const key = `industrialist_save_${credentialsRef.current.username || "guest"}`;
+            if (typeof window !== "undefined" && window.localStorage) {
+                window.localStorage.setItem(key, JSON.stringify({
+                    ...saveData,
+                    last_saved_at: Date.now(),
+                }));
+            }
+        } catch { void 0; }
+    }, [saveData, isAuthenticated]);
 
     const addResource = useCallback((resource: string, amount: number) => {
         if (amount <= 0) {


### PR DESCRIPTION
## Summary
- Persist save data to localStorage on every state change when authenticated
- Cache to localStorage after successful cloud saves as backup
- Existing error-path fallback now supplemented with proactive local caching

## Test plan
- [ ] Login and verify localStorage key `industrialist_save_<username>` is populated
- [ ] Disconnect network, verify "Sync Error - saved locally" appears
- [ ] Reconnect and verify data syncs back to cloud

🤖 Generated with [Claude Code](https://claude.com/claude-code)