### PR TITLE
Fix factory plots not unlocking after level completion (Fixes #24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to this project will be documented in this file.
 ## [0.8.2] - 2026-03-22 [Author: Filip Houdek]
 ### Verified
 - Verified offline progress calculation awards passively generated resources upon profile load based on last_saved_at timestamp (Fixes #15).
+## [0.7.9] - 2026-03-22 [Author: Filip Houdek]
+### Fixed
+- Fixed factory plots not unlocking after completing corresponding levels by syncing `highestLevelCompleted` from game progression to EconomyContext (Fixes #24).
 
 ## [0.7.5] - 2026-03-22 [Author: Tobias Mrazek]
 ### Fixed

--- a/frontend/components/fps-game.tsx
+++ b/frontend/components/fps-game.tsx
@@ -72,7 +72,7 @@ export default function FPSGame() {
   const previousGameStateRef = useRef<GameState>("mainMenu");
   const { settings, setSettings, updateSetting, isLoaded, resetSettings } = useSettings();
   const { registerClearRagdolls } = useGameActions();
-  const { isAuthenticated, logout, forceCloudSave, addResource, saveData, incrementKills } = useEconomy();
+  const { isAuthenticated, logout, forceCloudSave, addResource, saveData, incrementKills, updateHighestLevel } = useEconomy();
 
   const rendererRef = useRef<GameRenderer | null>(null);
 
@@ -337,6 +337,7 @@ export default function FPSGame() {
         unlockedWeapons: new Set([...prev.unlockedWeapons, ...weaponsUnlockedRef.current]),
         highestLevel: Math.max(prev.highestLevel, next),
       }));
+      updateHighestLevel(next);
       void forceCloudSave(undefined, totalKillsRef.current + killsRef.current);
       totalKillsRef.current += killsRef.current;
       beginLevelTransition(next, true);
@@ -346,7 +347,7 @@ export default function FPSGame() {
       setGameState("victory");
       void forceCloudSave(undefined, totalKillsRef.current + killsRef.current);
     }
-  }, [beginLevelTransition, forceCloudSave]);
+  }, [beginLevelTransition, forceCloudSave, updateHighestLevel]);
 
   const openFactory = useCallback(() => {
     if (!isAuthenticated) {
@@ -1062,6 +1063,7 @@ export default function FPSGame() {
           highestLevel: parsed.highestLevel
         });
         weaponsUnlockedRef.current = new Set(parsed.unlockedWeapons);
+        updateHighestLevel(parsed.highestLevel);
       } catch (e) {
         console.error("Failed to load savegame", e);
       }

--- a/frontend/context/EconomyContext.tsx
+++ b/frontend/context/EconomyContext.tsx
@@ -71,6 +71,7 @@ interface EconomyContextType {
     collectMachine: (machineId: string) => boolean;
     unlockWeapon: (weapon: string, barCost: number, creditCost: number) => boolean;
     incrementKills: (amount: number) => void;
+    updateHighestLevel: (level: number) => void;
 }
 
 const initialSaveData: EconomySaveData = {
@@ -189,6 +190,13 @@ export function EconomyProvider({ children }: { children: React.ReactNode }) {
 
     const incrementKills = useCallback((amount: number) => {
         setKills(prev => prev + amount);
+    }, []);
+
+    const updateHighestLevel = useCallback((level: number) => {
+        setSaveData((prev) => ({
+            ...prev,
+            highestLevelCompleted: Math.max(prev.highestLevelCompleted, level),
+        }));
     }, []);
 
     const awardOfflineProgress = useCallback((lastSavedAt?: number) => {
@@ -783,6 +791,7 @@ export function EconomyProvider({ children }: { children: React.ReactNode }) {
             collectMachine,
             unlockWeapon,
             incrementKills,
+            updateHighestLevel,
         };
     }, [
         addResource,
@@ -804,6 +813,7 @@ export function EconomyProvider({ children }: { children: React.ReactNode }) {
         upgradeMachine,
         username,
         incrementKills,
+        updateHighestLevel,
     ]);
 
     return <EconomyContext.Provider value={value}>{children}</EconomyContext.Provider>;


### PR DESCRIPTION
## Summary
- **Root cause**: `highestLevelCompleted` in EconomyContext (controls factory slot unlocks) was never updated from game progression
- Added `updateHighestLevel()` to EconomyContext and exposed it via the context
- Called from `nextLevel()` in fps-game.tsx when player completes a level
- Also synced on savegame load from localStorage

## Test plan
- [ ] Complete level 2 and verify second factory slot unlocks in Factory Hub
- [ ] Reload page and verify factory slots remain unlocked
- [ ] Verify existing factory functionality still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)