### PR TITLE
Remove unused dependencies (Fixes #32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Configured Dependabot for automated weekly npm dependency updates in the frontend directory (Fixes #30).
 - Defined a team process for reviewing and merging Dependabot PRs in the technical documentation.
+## [0.8.8] - 2026-03-22 [Author: Filip Houdek]
+### Removed
+- Performed dependency audit and removed unused libraries: `@hookform/resolvers`, `date-fns`, `autoprefixer`, `tailwindcss-animate` (Fixes #32).
 
 ## [0.7.5] - 2026-03-22 [Author: Tobias Mrazek]
 ### Fixed

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,6 @@
     ]
   },
   "dependencies": {
-    "@hookform/resolvers": "^3.10.0",
     "@prisma/client": "^5.22.0",
     "@radix-ui/react-accordion": "1.2.2",
     "@radix-ui/react-alert-dialog": "1.1.4",
@@ -52,12 +51,10 @@
     "@radix-ui/react-toggle-group": "1.1.1",
     "@radix-ui/react-tooltip": "1.1.6",
     "@vercel/analytics": "1.3.1",
-    "autoprefixer": "^10.4.20",
     "bcryptjs": "^3.0.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "1.0.4",
-    "date-fns": "4.1.0",
     "dompurify": "^3.3.3",
     "embla-carousel-react": "8.5.1",
     "input-otp": "1.4.1",
@@ -74,7 +71,6 @@
     "recharts": "2.15.4",
     "sonner": "^1.7.4",
     "tailwind-merge": "^3.3.1",
-    "tailwindcss-animate": "^1.0.7",
     "vaul": "^1.1.2",
     "zod": "3.25.76"
   },


### PR DESCRIPTION
## Summary
- Ran `depcheck` audit and removed 4 unused packages:
  - `@hookform/resolvers` - not imported anywhere
  - `date-fns` - not imported anywhere
  - `autoprefixer` - not used in postcss config
  - `tailwindcss-animate` - replaced by `tw-animate-css`

## Test plan
- [ ] Run `pnpm install` and verify no errors
- [ ] Run `pnpm build` and verify build succeeds
- [ ] Run `pnpm test` and verify tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)