### PR TITLE
Enable GZIP/Brotli compression (Fixes #37, #44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ All notable changes to this project will be documented in this file.
 ## [0.8.8] - 2026-03-22 [Author: Filip Houdek]
 ### Removed
 - Performed dependency audit and removed unused libraries: `@hookform/resolvers`, `date-fns`, `autoprefixer`, `tailwindcss-animate` (Fixes #32).
+## [0.7.7] - 2026-03-22 [Author: Filip Houdek]
+### Fixed
+- Enabled GZIP/Brotli compression in Next.js config by adding `compress: true` (Fixes #37, #44).
 
 ## [0.7.5] - 2026-03-22 [Author: Tobias Mrazek]
 ### Fixed

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -66,6 +66,8 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  // Enforce GZIP/Brotli compression for all responses
+  compress: true,
 }
 
 export default nextConfig


### PR DESCRIPTION
## Summary
- Added `compress: true` to Next.js config to enforce GZIP/Brotli compression for all server responses

## Test plan
- [ ] Build and run production server
- [ ] Verify `Content-Encoding: gzip` header in responses via `curl -I -H "Accept-Encoding: gzip"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)