### PR TITLE
Enable image optimization and static asset caching (Fixes #48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ All notable changes to this project will be documented in this file.
 ## [0.7.7] - 2026-03-22 [Author: Filip Houdek]
 ### Fixed
 - Enabled GZIP/Brotli compression in Next.js config by adding `compress: true` (Fixes #37, #44).
+## [0.7.8] - 2026-03-22 [Author: Filip Houdek]
+### Added
+- Enabled Next.js image optimization and added Cache-Control headers for static assets (JS, CSS, images) (Fixes #48).
 
 ## [0.7.5] - 2026-03-22 [Author: Tobias Mrazek]
 ### Fixed

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -58,13 +58,31 @@ const nextConfig = {
           },
         ],
       },
+      {
+        source: '/_next/static/:path*',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=31536000, immutable',
+          },
+        ],
+      },
+      {
+        source: '/images/:path*',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=86400, must-revalidate',
+          },
+        ],
+      },
     ];
   },
   typescript: {
     ignoreBuildErrors: true,
   },
   images: {
-    unoptimized: true,
+    unoptimized: false,
   },
   // Enforce GZIP/Brotli compression for all responses
   compress: true,


### PR DESCRIPTION
## Summary
- Removed `unoptimized: true` from Next.js images config to enable optimization
- Added `Cache-Control` headers for `/_next/static/` (immutable, 1 year) and `/images/` (1 day)

## Test plan
- [ ] Verify images are served optimized via `/_next/image`
- [ ] Check `Cache-Control` headers on static assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)