### PR TITLE
Add load testing for concurrent players (Fixes #62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ All notable changes to this project will be documented in this file.
 ## [0.8.5] - 2026-03-22 [Author: Filip Houdek]
 ### Added
 - Documented and verified HTTP cache functionality for static assets (Fixes #49).
+## [0.8.6] - 2026-03-22 [Author: Filip Houdek]
+### Added
+- Added Artillery load testing configuration for simulating concurrent players (Fixes #62).
+- Created `docs/concurrent-users-test.md` documenting test methodology and expected metrics.
 
 ## [0.7.5] - 2026-03-22 [Author: Tobias Mrazek]
 ### Fixed

--- a/docs/concurrent-users-test.md
+++ b/docs/concurrent-users-test.md
@@ -1,0 +1,26 @@
+# Concurrent Users Load Test
+
+## Tool
+[Artillery](https://www.artillery.io/) - a modern load testing toolkit.
+
+## Configuration
+The load test configuration is at `frontend/scripts/load-test.yml`.
+
+### Test Phases
+1. **Warm-up** (30s): 5 virtual users/second
+2. **Sustained load** (60s): 20 virtual users/second
+3. **Peak load** (30s): 50 virtual users/second
+
+### Scenarios Tested
+- **Leaderboard access**: GET `/api/leaderboard` — simulates players checking scores
+- **Authentication flow**: POST `/api/auth/login` — simulates concurrent login attempts
+
+## How to Run
+1. Start the production server: `pnpm build && pnpm start`
+2. In a separate terminal: `pnpm test:load`
+3. Artillery will output metrics including latency percentiles, RPS, and error rates.
+
+## Expected Metrics
+- p95 latency < 500ms under sustained load
+- Error rate < 1% under sustained load
+- Server remains responsive during peak load

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "next dev",
     "lint": "eslint .",
     "start": "next start",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:load": "artillery run scripts/load-test.yml"
   },
   "pnpm": {
     "onlyBuiltDependencies": [
@@ -98,6 +99,7 @@
     "typescript": "^5",
     "typescript-eslint": "^8.54.0",
     "vitest": "^4.0.18",
-    "vitest-mock-extended": "^3.1.0"
+    "vitest-mock-extended": "^3.1.0",
+    "artillery": "^2.0.22"
   }
 }

--- a/frontend/scripts/load-test.yml
+++ b/frontend/scripts/load-test.yml
@@ -1,0 +1,33 @@
+config:
+  target: "http://localhost:3000"
+  phases:
+    - duration: 30
+      arrivalRate: 5
+      name: "Warm-up"
+    - duration: 60
+      arrivalRate: 20
+      name: "Sustained load"
+    - duration: 30
+      arrivalRate: 50
+      name: "Peak load"
+
+scenarios:
+  - name: "Leaderboard access"
+    flow:
+      - get:
+          url: "/api/leaderboard"
+          expect:
+            - statusCode: 200
+
+  - name: "Authentication flow"
+    flow:
+      - post:
+          url: "/api/auth/login"
+          json:
+            username: "loadtest_user"
+            password: "loadtest_pass"
+            loginToken: "test"
+          expect:
+            - statusCode:
+                - 200
+                - 401


### PR DESCRIPTION
## Summary
- Added Artillery load test config (`frontend/scripts/load-test.yml`) with 3 phases: warm-up, sustained, peak
- Added `test:load` script to package.json
- Created `docs/concurrent-users-test.md` documenting methodology

## Test plan
- [ ] Run `pnpm build && pnpm start`, then `pnpm test:load`
- [ ] Review Artillery output for latency and error metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)